### PR TITLE
ジャンル選択時の挙動を改善

### DIFF
--- a/main.py
+++ b/main.py
@@ -544,7 +544,9 @@ class ButtonPanel(wx.Panel):
             titlelist = [self.af.title] + [self.sc.title]
             albumlist = [self.af.album]
             artistlist = [self.af.artist] + [self.sc.artist]
-            genrelist = [self.af.genre] + [self.sc.maintag] + self.sc.taglist
+            genrelist =  [self.af.genre] if not self.af.genre == '' else []
+            genrelist += [self.sc.maintag] if not self.sc.maintag == '' else []
+            genrelist += self.sc.taglist
 
             self.cb_title.SetItems(titlelist)
             self.cb_album.SetItems(albumlist)

--- a/main.py
+++ b/main.py
@@ -565,10 +565,12 @@ class ButtonPanel(wx.Panel):
                 self.cb_artist.SetValue(self.af.artist)
 
             if self.af.genre == '':
-                if self.sc.maintag == '':
+                if not self.sc.maintag == '':
+                    self.cb_genre.SetLabel(self.sc.maintag)
+                elif not self.sc.taglist == []:
                     self.cb_genre.SetLabel('選択してください')
                 else:
-                    self.cb_genre.SetLabel(self.sc.maintag)
+                    self.cb_genre.SetLabel('')
             else:
                 self.cb_genre.SetLabel(self.af.genre)
 


### PR DESCRIPTION
#28

## 作業内容
- SCのサブジャンル未登録時は，ラベルに空文字を設定
- SCのサブジャンルが存在する場合のみ"選択してください"を表示
- ドロップダウンリスト表示時，空の要素を含めないように