### PR TITLE
Fix: filename extraction

### DIFF
--- a/audiofile.py
+++ b/audiofile.py
@@ -402,7 +402,7 @@ class AudioFile():
         except:
             raise JsonLoadError("jsonファイルを読み込めませんでした")
 
-        filename = self.filepath.split(".")[-2]
+        filename = os.path.splitext(os.path.basename(self.filepath))[0]
         old_filepath = self.filepath
         new_filepath = filename + '.' + config["format"]
 


### PR DESCRIPTION
Issue #42 の修正 

ドットが複数含まれるファイル名の場合、ファイル名が欠落する問題の修正

# ファイル名抽出例
入力: ```aa.bb.cc.wav``
出力_修正前: ```cc```
出力_修正後: ```aa.bb.cc```